### PR TITLE
tz_parse_syscalls: Fix treating 0 as an invalid version

### DIFF
--- a/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py
+++ b/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py
@@ -55,7 +55,7 @@ with open("{}/VERSION".format(args.zephyr_base), "r") as fh:
         elif matches := re.match('^PATCHLEVEL\s*=\s*(\d+)$', line):
             patch_level = int(matches.group(1))
 
-    if not major or not minor or not patch_level:
+    if major is None or minor is None or patch_level is None:
         print("Invalid version specified: major: {}, minor: {}, patchlevel: {}, exiting...".format(major, minor, patch_level))
         exit(1)
 


### PR DESCRIPTION
The tz_parse_syscalls script was likely trying to catch missing major, minor or patchlevel versions, however it ended up treating the value 0 and None as the same thing. Fix this by explicitly checking for None.