### PR TITLE
zephyr: namespace the generated `version.h`

### DIFF
--- a/TraceRecorder/kernelports/Zephyr/include/trcKernelPort.h
+++ b/TraceRecorder/kernelports/Zephyr/include/trcKernelPort.h
@@ -12,7 +12,7 @@
 #define TRC_KERNEL_PORT_H
 
 #include <zephyr/kernel.h>
-#include <version.h>
+#include <zephyr/version.h>
 #include <trcRecorder.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Zephyr's build time generated `version.h` is now in the `zephyr` to provide proper namespace, update the includes of this module accordingly.

See https://github.com/zephyrproject-rtos/zephyr/pull/63973